### PR TITLE
Update extension name, description. Add README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+## ADB Extension
+
+This is a Firefox extension that supports remote debugging in Firefox DevTools.
+It provides ADB binaries used by DevTools to connect to Firefox/GeckoView products on Android devices via USB.
+
+### Releases
+
+For documentation about releases check out [RELEASE.md](./RELEASE.md)
+
+### Discussion
+
+For questions and issues specific to this extension, you can use the [GitHub issue tracker](https://github.com/mozilla/devtools-adb-extension/issues).
+
+For more general questions about remote debugging in DevTools or DevTools in general, you can:
+- come chat with us on [Slack](https://devtools-html-slack.herokuapp.com/) or IRC (#devtools at irc.mozilla.org)
+- file bugs on [Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?product=DevTools)

--- a/extension/template-manifest.json
+++ b/extension/template-manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 2,
-  "name": "ADB binary provider",
+  "name": "Firefox DevTools ADB Extension",
   "author": "Mozilla & Android Open Source Project",
   "version": "@@VERSION@@",
-  "description": "An extension providing ADB blobs for connecting to Firefox for Android",
+  "description": "An extension providing ADB binaries for Android remote debugging in Firefox DevTools. May be automatically installed when using WebIDE or about:debugging.",
   "applications": {
     "gecko": {
       "id": "adb@mozilla.org",


### PR DESCRIPTION
Addresses #10 and #11 

I am not in favor of hiding the extension from about:addons (#8 ) just yet, because when we initially roll out the new remote debugging, it would be great to be able to check if the extension is installed or provide ways to uninstall it easily for users who have issues.

Very explicit name "Firefox DevTools ADB extension" so that users know easily that this comes from devtools. Description also mentions that the extension can be automatically installed because users might wonder why the extension popped up in about:addons.

Finally a succint README.md in case users end up on this repository and want to get in touch.