### PR TITLE
Add Windows/aarch64 support

### DIFF
--- a/extension/adb.json
+++ b/extension/adb.json
@@ -13,6 +13,11 @@
     ]
   },
   "WINNT": {
+    "aarch64": [
+      "win32/adb.exe",
+      "win32/AdbWinApi.dll",
+      "win32/AdbWinUsbApi.dll"
+    ],
     "x86": [
       "win32/adb.exe",
       "win32/AdbWinApi.dll",


### PR DESCRIPTION
TARGET_XCOM_ABI of Windows/aarch64 is `aarch64-msvc`, so we cannot use remote debugging using Firefox for aarch64.  Since Windows/aarch64 can run x86 binary, we should use win32 binary even if aarch64.